### PR TITLE
fix function action

### DIFF
--- a/src/repository.js
+++ b/src/repository.js
@@ -21,11 +21,11 @@ const GetRepositoryInfoQuery = gql`
 `;
 
 const withInfo = graphql(GetRepositoryInfoQuery, {
-  options: ({ login, name }) => {
+  options: ({ login = "facebook" , name = "react" }) => {
     return {
       variables: {
-        login: 'facebook',
-        name: 'react'
+        login,
+        name
       }
     }
   },


### PR DESCRIPTION
Previously the function would always return facebook and react, this way we can pass new login and repos, but default to facebook/react if none are set